### PR TITLE
APIコール時の:id差し替えが出来ない問題を修正

### DIFF
--- a/lib/private.js
+++ b/lib/private.js
@@ -22,8 +22,8 @@ private_methods = METHODS.reduce( (a, e) => {
     const timestamp = Date.now().toString();
     const method = e.method;
     const query_str = (query && method === 'GET') ? `?${qs.stringify(query)}` : ''
-    const path = `https://coincheck.com/api/${e.uri}${query_str}`;
-    if (query && query.id) path.replace(/\/\:id\//, `/${query.id}/`)
+    let path = `https://coincheck.com/api/${e.uri}${query_str}`;
+    if (query && query.id) path = path.replace(/\/\:id/, `/${query.id}`)
     const body = (query && method === 'POST') ? JSON.stringify(query): "";
     const text = timestamp + path + body;
     const sign = crypto.createHmac('sha256', secret).update(text).digest('hex');


### PR DESCRIPTION
オーダのキャンセルを試してみたところ、:idが差し替えられていないようで
エラーが発生したため、該当箇所を修正してみました。

テストはありませんが、実際にこのコードでオーダをキャンセルできることを確認しています。